### PR TITLE
Fix wrong spelling of Voskresenska Street in rename.json

### DIFF
--- a/rename.json
+++ b/rename.json
@@ -1608,7 +1608,7 @@
             {
                 "type": "street", 
                 "oldName": "Леніна",
-                "newName": "Воскресеньска",
+                "newName": "Воскресенська",
                 "restored": true
             },
             {


### PR DESCRIPTION
Исправление строки 1611. Улица Воскресенская встречается в двух районах, в первом упоминании (строка 763) написание верное - `Воскресе[нсь]ка`, а во втором (строка 1611) неверное - `Воскресе[ньс]ка`.
