### PR TITLE
Add renaming data

### DIFF
--- a/rename.json
+++ b/rename.json
@@ -1874,6 +1874,15 @@
                 "newName": "Білих акацій"
             },
             {
+                "type": "avenue", 
+                "oldName": "Калініна",
+                "newName": "Нігояна",
+                "link": {
+                    "href": "https://uk.wikipedia.org/wiki/%D0%9D%D1%96%D0%B3%D0%BE%D1%8F%D0%BD_%D0%A1%D0%B5%D1%80%D0%B3%D1%96%D0%B9_%D0%93%D0%B0%D0%B3%D1%96%D0%BA%D0%BE%D0%B2%D0%B8%D1%87",
+                    "type": 0
+                }
+            },
+            {
                 "type": "lane", 
                 "oldName": "Калініна",
                 "newName": "Січовий",


### PR DESCRIPTION
Повторное переименование просп. Калинина в Нигояна после отмены решения.
- https://www.radiosvoboda.org/a/news/28919845.html